### PR TITLE
Update blueprint to use price descriptor in 2022.4 update

### DIFF
--- a/home-assistant/blueprints/light.yaml
+++ b/home-assistant/blueprints/light.yaml
@@ -3,14 +3,14 @@ blueprint:
   description: Change the colour of a lamp based on the current Amber price
   domain: automation
   input:
-    amber_price_sensor:
-      name: Amber Price Sensor
-      description: The Amber price sensor you wish to track. If in doubt, use General Price.
+    amber_price_descriptor:
+      name: Amber Price Descriptor
+      description: The Amber price descriptor you wish to track. If in doubt, use General
+        Price.
       selector:
         entity:
           integration: amberelectric
           domain: sensor
-
     target_light:
       name: Light
       description: The light you wish to use as the indicator
@@ -18,64 +18,29 @@ blueprint:
         target:
           entity:
             domain: light
-
-    low_price:
-      name: Low price
-      description: Price above this threshold will show green. Below will show Cyan
-      selector:
-        number:
-          mode: box
-          min: -1
-          max: 16.5
-          step: 0.01
-      default: 0.16
-
-    average_price:
-      name: Average price
-      description: Price above this threshold will show yellow.
-      selector:
-        number:
-          mode: box
-          min: -1
-          max: 16.5
-          step: 0.01
-      default: 0.25
-
-    high_price:
-      name: High price
-      description: Price above this threshold will show red.
-      selector:
-        number:
-          mode: box
-          min: -1
-          max: 16.5
-          step: 0.01
-      default: 0.4
-
+  source_url: https://github.com/amberelectric/public-api/blob/main/home-assistant/blueprints/light.yaml
 trigger:
-  - platform: state
-    entity_id: !input amber_price_sensor
-
+- platform: state
+  entity_id: !input 'amber_price_descriptor'
 action:
-  - variables:
-      spot_price: "{{ trigger.to_state.attributes.spot_per_kwh }}"
-      customer_price: "{{ trigger.to_state.attributes.per_kwh }}"
-      low_price: !input low_price
-      average_price: !input average_price
-      high_price: !input high_price
-
-  - service: light.turn_on
-    target: !input target_light
-    data:
-      color_name: >
-        {% if spot_price >= 3 %}
-          purple
-        {% elif customer_price > high_price %}
-          red
-        {% elif customer_price > average_price %}
-          orange
-        {% elif customer_price > low_price %}
-          green
-        {% else %}
-          cyan
-        {% endif %}
+- variables:
+    price_descriptor: '{{ trigger.to_state.state }}'
+- service: light.turn_on
+  target: !input 'target_light'
+  data:
+    color_name: >
+      {% if price_descriptor == 'spike' %}
+        purple
+      {% elif price_descriptor == 'high' %}
+        red
+      {% elif price_descriptor == 'neutral' %}
+        darkorange
+      {% elif price_descriptor == 'low' %}
+        orange
+      {% elif price_descriptor == 'verylow' %}
+        green
+      {% elif price_descriptor == 'extremelyLow' %}
+        cyan
+      {% else %}
+        white
+      {% endif %}

--- a/home-assistant/blueprints/light.yaml
+++ b/home-assistant/blueprints/light.yaml
@@ -18,7 +18,7 @@ blueprint:
         target:
           entity:
             domain: light
-  source_url: https://github.com/amberelectric/public-api/blob/main/home-assistant/blueprints/light.yaml
+
 trigger:
 - platform: state
   entity_id: !input 'amber_price_descriptor'


### PR DESCRIPTION
As seen in home-assistant/core#67981 update for 2022.4 using the price descriptors.

May need to modify (as my LED lights dont do yellow very well)

Tested against HASS 2022.4.0b1