### PR TITLE
Update price levels

### DIFF
--- a/home-assistant/blueprints/light.yaml
+++ b/home-assistant/blueprints/light.yaml
@@ -37,9 +37,9 @@ action:
         darkorange
       {% elif price_descriptor == 'low' %}
         orange
-      {% elif price_descriptor == 'verylow' %}
+      {% elif price_descriptor == 'very_low' %}
         green
-      {% elif price_descriptor == 'extremelyLow' %}
+      {% elif price_descriptor == 'extremely_low' %}
         cyan
       {% else %}
         white


### PR DESCRIPTION
First time this week that prices in QLD have been "normal". Saw my lights were white (negative) and checked because it didn't sound right.

When looking at the integration I used the API values, not the `snake_case` translation in [the source](https://github.com/home-assistant/core/blob/02d245a31a03805708e8de0471eb3656458e7ffe/homeassistant/components/amberelectric/coordinator.py#L49) and used these to test the integration.

Derp.