### PR TITLE
Re-add 'items' tag in the return of '/sites'

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -697,7 +697,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "$ref": "#/components/schemas/Site"
+                  "items": {
+                    "$ref": "#/components/schemas/Site"
+                  }
                 }
               }
             }


### PR DESCRIPTION
In /sites return, the items tag for the array got deleted. Re-adding it.