### PR TITLE
Remove extra tags from Interval.

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -278,8 +278,6 @@
             "$ref": "#/components/schemas/ChannelType"
           },
           "tariffInformation": {
-            "type": "object",
-            "description": "Information about how your tariff is affecting this interval",
             "nullable": true,
             "$ref": "#/components/schemas/TariffInformation"
           },


### PR DESCRIPTION
It seems that these tags are already covered by the ref to TariffInformation.