### PR TITLE
To define a date you need both format:date/-time and type:string.

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -748,7 +748,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date"
             }
           },
           {
@@ -999,7 +999,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date"
             }
           },
           {

--- a/swagger.json
+++ b/swagger.json
@@ -736,6 +736,7 @@
             "example": "2021-05-05",
             "required": false,
             "schema": {
+              "type": "string",
               "format": "date"
             }
           },
@@ -746,6 +747,7 @@
             "example": "2021-05-05",
             "required": false,
             "schema": {
+              "type": "string",
               "format": "date-time"
             }
           },
@@ -985,6 +987,7 @@
             "example": "2021-05-05",
             "required": true,
             "schema": {
+              "type": "string",
               "format": "date"
             }
           },
@@ -995,6 +998,7 @@
             "example": "2021-05-05",
             "required": true,
             "schema": {
+              "type": "string",
               "format": "date-time"
             }
           },


### PR DESCRIPTION
Adds 
- "type": "string"

To a couple of date fields that were missing it.