### PR TITLE
Use the same format for both startDate and endDate in /prices and /us…

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -736,7 +736,7 @@
             "example": "2021-05-05",
             "required": false,
             "schema": {
-              "format": "date"
+              "format": "date-time"
             }
           },
           {
@@ -985,7 +985,7 @@
             "example": "2021-05-05",
             "required": true,
             "schema": {
-              "format": "date"
+              "format": "date-time"
             }
           },
           {


### PR DESCRIPTION
Use the same format for both startDate and endDate in /prices and /usage.

endDate uses 'date-time'.
This changes startDate from 'date' to 'date-time' to match.

