### PR TITLE
Fix the 'requires' in Renewable to match the name in 'properties'.

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -418,7 +418,7 @@
           "startTime",
           "endTime",
           "renewables",
-          "renewablePriceDescriptor"
+          "descriptor"
         ],
         "properties": {
           "type": {


### PR DESCRIPTION
The "requires" in Renewable did not match what is in "properties" for the renewablePriceDescriptor / descriptor.

Resolve in favour of what was in properties, as this is less likely to break API compatibility with a name change.