### PR TITLE
Use ref ChannelType in Channel

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -32,14 +32,7 @@
             "example": "E1"
           },
           "type": {
-            "type": "string",
-            "enum": [
-              "general",
-              "controlledLoad",
-              "feedIn"
-            ],
-            "description": "Channel type.",
-            "example": "general"
+            "$ref": "#/components/schemas/ChannelType"
           },
           "tariff": {
             "type": "string",

--- a/swagger.json
+++ b/swagger.json
@@ -137,7 +137,8 @@
           "general",
           "controlledLoad",
           "feedIn"
-        ]
+        ],
+        "example": "general"
       },
       "Range": {
         "type": "object",


### PR DESCRIPTION
Remove duplication by using $ref ChannelType in Channel.
Also moved the example of "general" to ChannelType since it was missing one.