### PR TITLE
Change use of anyOf to oneOf when returning arrays of 'sub-types'

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -611,7 +611,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "anyOf": [
+                    "oneOf": [
                       {
                         "$ref": "#/components/schemas/ActualRenewable"
                       },
@@ -794,7 +794,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "anyOf": [
+                    "oneOf": [
                       {
                         "$ref": "#/components/schemas/ActualInterval"
                       },
@@ -917,7 +917,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "anyOf": [
+                    "oneOf": [
                       {
                         "$ref": "#/components/schemas/ActualInterval"
                       },


### PR DESCRIPTION
Each element in the return arrays from calls such as "/sites/{siteId}/prices" is distinctly one of the subschema.
ie. ActualInterval, CurrentInterval or ForecastInterval

As such, oneOf is likely much more representative of the actual data than anyOf would be.
anyOf could potentially allow for return elements that are a mix of a CurrentInterval and a ForecastInterval together, which seems very unlikely.

