### PR TITLE
Add empty security tag for: /state/{state}/renewables/current

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -534,6 +534,8 @@
     "/state/{state}/renewables/current": {
       "get": {
         "description": "Returns the current percentage of renewables in the grid",
+        "security": [
+        ],
         "parameters": [
           {
             "name": "state",


### PR DESCRIPTION
This defines that it is a public call and does not require a token.

Apparently it is good practice to define the security tag, even if it is empty.
