### PR TITLE
Consolidate discriminators

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -200,6 +200,27 @@
           }
         }
       },
+      "IntervalMetaType": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ActualInterval"
+          },
+          {
+            "$ref": "#/components/schemas/CurrentInterval"
+          },
+          {
+            "$ref": "#/components/schemas/ForecastInterval"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "ActualInterval": "#/components/schemas/ActualInterval",
+            "ForecastInterval": "#/components/schemas/ForecastInterval",
+            "CurrentInterval": "#/components/schemas/CurrentInterval"
+          }
+        }
+      },
       "Interval": {
         "type": "object",
         "description": "One time interval",
@@ -766,25 +787,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ActualInterval"
-                      },
-                      {
-                        "$ref": "#/components/schemas/CurrentInterval"
-                      },
-                      {
-                        "$ref": "#/components/schemas/ForecastInterval"
-                      }
-                    ],
-                    "discriminator": {
-                      "propertyName": "type",
-                      "mapping": {
-                        "ActualInterval": "#/components/schemas/ActualInterval",
-                        "ForecastInterval": "#/components/schemas/ForecastInterval",
-                        "CurrentInterval": "#/components/schemas/CurrentInterval"
-                      }
-                    }
+                    "$ref": "#/components/schemas/IntervalMetaType"
                   }
                 }
               }
@@ -877,25 +880,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ActualInterval"
-                      },
-                      {
-                        "$ref": "#/components/schemas/CurrentInterval"
-                      },
-                      {
-                        "$ref": "#/components/schemas/ForecastInterval"
-                      }
-                    ],
-                    "discriminator": {
-                      "propertyName": "type",
-                      "mapping": {
-                        "ActualInterval": "#/components/schemas/ActualInterval",
-                        "ForecastInterval": "#/components/schemas/ForecastInterval",
-                        "CurrentInterval": "#/components/schemas/CurrentInterval"
-                      }
-                    }
+                    "$ref": "#/components/schemas/IntervalMetaType"
                   }
                 }
               }

--- a/swagger.json
+++ b/swagger.json
@@ -218,6 +218,9 @@
           "descriptor"
         ],
         "properties": {
+          "type": {
+            "type": "string"
+          },
           "duration": {
             "type": "number",
             "description": "Length of the interval in minutes.",
@@ -287,17 +290,6 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/Interval"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "ActualInterval"
-                ]
-              }
-            }
           }
         ]
       },
@@ -310,12 +302,6 @@
             "type": "object",
             "description": "Returns a forecasted price based on AEMO modelling. This is what AEMO thinks the price will be during the interval.",
             "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "ForecastInterval"
-                ]
-              },
               "range": {
                 "nullable": true,
                 "$ref": "#/components/schemas/Range"
@@ -336,12 +322,6 @@
               "estimate"
             ],
             "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "CurrentInterval"
-                ]
-              },
               "range": {
                 "nullable": true,
                 "$ref": "#/components/schemas/Range"

--- a/swagger.json
+++ b/swagger.json
@@ -466,55 +466,22 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/Renewable"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "ActualRenewable"
-                ]
-              }
-            }
           }
         ]
       },
       "ForecastRenewable": {
+        "description": "Returns a forecasted renewables based on AEMO modelling. This is what AEMO thinks the renewables will be during the interval.",
         "allOf": [
           {
             "$ref": "#/components/schemas/Renewable"
-          },
-          {
-            "type": "object",
-            "description": "Returns a forecasted renewables based on AEMO modelling. This is what AEMO thinks the renewables will be during the interval.",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "ForecastRenewable"
-                ]
-              }
-            }
           }
         ]
       },
       "CurrentRenewable": {
+        "description": "Returns the current interval's renewables",
         "allOf": [
           {
             "$ref": "#/components/schemas/Renewable"
-          },
-          {
-            "type": "object",
-            "description": "Returns the current interval's renewables",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "CurrentRenewable"
-                ]
-              }
-            }
           }
         ]
       }

--- a/swagger.json
+++ b/swagger.json
@@ -400,6 +400,27 @@
           }
         ]
       },
+      "RenewableMetaType": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ActualRenewable"
+          },
+          {
+            "$ref": "#/components/schemas/CurrentRenewable"
+          },
+          {
+            "$ref": "#/components/schemas/ForecastRenewable"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "ActualRenewable": "#/components/schemas/ActualRenewable",
+            "ForecastRenewable": "#/components/schemas/ForecastRenewable",
+            "CurrentRenewable": "#/components/schemas/CurrentRenewable"
+          }
+        }
+      },
       "Renewable": {
         "type": "object",
         "description": "Renewable data",
@@ -592,25 +613,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/ActualRenewable"
-                      },
-                      {
-                        "$ref": "#/components/schemas/CurrentRenewable"
-                      },
-                      {
-                        "$ref": "#/components/schemas/ForecastRenewable"
-                      }
-                    ],
-                    "discriminator": {
-                      "propertyName": "type",
-                      "mapping": {
-                        "ActualRenewable": "#/components/schemas/ActualRenewable",
-                        "ForecastRenewable": "#/components/schemas/ForecastRenewable",
-                        "CurrentRenewable": "#/components/schemas/CurrentRenewable"
-                      }
-                    }
+                    "$ref": "#/components/schemas/RenewableMetaType"
                   }
                 }
               }

--- a/swagger.json
+++ b/swagger.json
@@ -507,9 +507,6 @@
           {
             "type": "object",
             "description": "Returns the current interval's renewables",
-            "required": [
-              "estimate"
-            ],
             "properties": {
               "type": {
                 "type": "string",


### PR DESCRIPTION
Change 1:
Ensure that discriminator type fields are only defined once, in the parent Schema of Interval and Renewable.
The existing file defined them in both the parent schema and the subschema.

Change 2:
Merge discriminator usage into dedicated types:
- IntervalMetaType
- RenewableMetaType

Benefits:
- Less code duplication around discriminators.
- Moves discriminators out of Operation Objects and into the main Schema where it is more maintainable.

Change 3:
Side note: I noticed that CurrentRenewable had a required field of 'estimate' but this was never actually defined within the CurrentRenewable properties. I have removed the requires for it.