### PR TITLE
Change Renewable.duration from type:number to type:integer. Same for Interval.duration.

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -219,7 +219,7 @@
         ],
         "properties": {
           "duration": {
-            "type": "number",
+            "type": "integer",
             "description": "Length of the interval in minutes.",
             "enum": [
               5,
@@ -417,7 +417,7 @@
             "type": "string"
           },
           "duration": {
-            "type": "number",
+            "type": "integer",
             "description": "Length of the interval in minutes.",
             "enum": [
               5,


### PR DESCRIPTION
Change the last two durations types that were using 'number' to use 'integer'.

Resolves #173