### PR TITLE
Remove required fields list from CurrentRenewable. 

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -506,9 +506,6 @@
           {
             "type": "object",
             "description": "Returns the current interval's renewables",
-            "required": [
-              "estimate"
-            ],
             "properties": {
               "type": {
                 "type": "string",


### PR DESCRIPTION
Remove required fields list from CurrentRenewable.
The only property listed was 'estimate' and it does not exist.