### PR TITLE
Fix example formatting.

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -230,12 +230,12 @@
           "spotPerKwh": {
             "type": "number",
             "description": "NEM spot price (c/kWh). This is the price generators get paid to generate electricity, and what drives the variable component of your perKwh price - includes GST",
-            "example": "6.12"
+            "example": 6.12
           },
           "perKwh": {
             "type": "number",
             "description": "Number of cents you will pay per kilowatt-hour (c/kWh) - includes GST",
-            "example": "24.33"
+            "example": 24.33
           },
           "date": {
             "type": "string",
@@ -266,7 +266,7 @@
             "description": "Percentage of renewables in the grid",
             "minimum": 0,
             "maximum": 100,
-            "example": "45"
+            "example": 45
           },
           "channelType": {
             "$ref": "#/components/schemas/ChannelType"
@@ -454,7 +454,7 @@
             "description": "Percentage of renewables in the grid",
             "minimum": 0,
             "maximum": 100,
-            "example": "45"
+            "example": 45
           },
           "descriptor": {
             "$ref": "#/components/schemas/RenewableDescriptor"


### PR DESCRIPTION
Fixed several example values that were strings and didn't need to be.

Per OpenAPI 3.0.0, string examples should be to 'represent examples that cannot be naturally represented in JSON'.

Since these were simple number types, I have removed the quotes around them.


Carl.