### PR TITLE
Fix nullable $ref issues, where the ref being nullable could be ignored.

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -273,7 +273,9 @@
           },
           "tariffInformation": {
             "nullable": true,
-            "$ref": "#/components/schemas/TariffInformation"
+            "allOf": [
+              "$ref": "#/components/schemas/TariffInformation"
+            ]
           },
           "spikeStatus": {
             "$ref": "#/components/schemas/SpikeStatus"
@@ -318,7 +320,9 @@
               },
               "range": {
                 "nullable": true,
-                "$ref": "#/components/schemas/Range"
+                "allOf": [
+                  "$ref": "#/components/schemas/Range"
+                ]
               }
             }
           }
@@ -344,7 +348,9 @@
               },
               "range": {
                 "nullable": true,
-                "$ref": "#/components/schemas/Range"
+                "allOf": [
+                  "$ref": "#/components/schemas/Range"
+                ]
               },
               "estimate": {
                 "type": "boolean",


### PR DESCRIPTION
In several places $ref objects existed that were intended to be nullable.

Per the 3.0.0 standard, under the heading Reference Object, 'This object cannot be extended with additional properties and any properties added SHALL be ignored.'. 

The workaround to having a nullable ref object is to wrap the ref in an allOf.


Carl.

