### PR TITLE
Fix apparent typo in Usage, required. 

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -362,7 +362,7 @@
           {
             "type": "object",
             "required": [
-              "channel",
+              "channelIdentifier",
               "kwh",
               "quality",
               "cost"


### PR DESCRIPTION
Fix apparent typo in Usage, required. 
Required contained 'channel', field name in properties is 'channelIdentifier'.