### PR TITLE
Specify in the description of Range that the values are Spot prices.

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -142,7 +142,7 @@
       },
       "Range": {
         "type": "object",
-        "description": "When prices are particularly volatile, the API may return a range of prices that are possible.",
+        "description": "When prices are particularly volatile, the API may return a range of NEM spot prices (c/kWh) that are possible.",
         "required": [
           "min",
           "max"


### PR DESCRIPTION
Update the description of Range to specify that the prices are spot prices. 
Per the answer given in #193.

Hopefully this saves someone else a bit of time and prevents confusion.


Thanks,
Carl.